### PR TITLE
Add null from default for NativeLanguage on user.js

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -88,7 +88,8 @@ const userSchema = new Schema(
       enum: {
         values: SPOKEN_LANG_ENUM,
         message: ENUM_CAN_BE_ONE_OF('native language', SPOKEN_LANG_ENUM)
-      }
+      },
+      default: null
     },
     isEmailConfirmed: {
       type: Boolean,


### PR DESCRIPTION
###Issue
Open https://github.com/WebUI-Project-Based-10-nr/BackEnd/issues/12 User nativeLanguage should be null by default

###Description
Fixed the bug by adding default value for NativeLanguage in user.js 

###Assignees
assignees: @geersann